### PR TITLE
Correct spelling of Cocoapods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EasyTransition
 [![Build Status](https://travis-ci.org/indevizible/EasyTransition.svg?branch=master)](https://travis-ci.org/indevizible/EasyTransition.svg?branch=master)
-[![Cocoapods Compatible](https://img.shields.io/cocoapods/v/EasyTransition.svg)](https://img.shields.io/cocoapods/v/EasyTransition.svg)
+[![CocoaPods Compatible](https://img.shields.io/cocoapods/v/EasyTransition.svg)](https://img.shields.io/cocoapods/v/EasyTransition.svg)
 [![Carthage Compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![GitHub license](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://raw.githubusercontent.com/indevizible/EasyTransition/master/LICENSE)
 [![Platform](https://img.shields.io/cocoapods/p/EasyTransition.svg?style=flat)](http://cocoadocs.org/docsets/EasyTransition)
@@ -105,7 +105,7 @@ And more on EasyTransitionExample.xcodeproj
 ## Sources Used
 - www.subtlepatterns.com
 - www.unsplash.com
-- [Alamofire/Alamofire](https://github.com/Alamofire/Alamofire) for Cocoapods and Carthage description
+- [Alamofire/Alamofire](https://github.com/Alamofire/Alamofire) for CocoaPods and Carthage description
 - [prolificinteractive/NavigationControllerBlurTransition](https://github.com/prolificinteractive/NavigationControllerBlurTransition) for [UIView+Constraints.swift](https://github.com/prolificinteractive/NavigationControllerBlurTransition/blob/master/Pod/Classes/UIView%2BConstraints.swift)
 
 ## Author


### PR DESCRIPTION
<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
